### PR TITLE
Chore - Full Calendar v3 Support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,10 +16,10 @@
     "package.json"
   ],
   "dependencies": {
-    "angular": ">=1.4.x",
+    "angular": ">=1.5.x",
     "jquery": "~3.1.1",
-    "fullcalendar": "~2.9.1",
-    "moment": ">=2.5.0"
+    "fullcalendar": "~3.1.0",
+    "moment": ">=2.9.0"
   },
   "devDependencies": {
     "angular-mocks": "~1.x",
@@ -27,6 +27,6 @@
   },
   "resolutions": {
     "jquery": "^3.1.1",
-    "angular": ">=1.4.x"
+    "angular": ">=1.5.x"
   }
 }


### PR DESCRIPTION
Bumps dependencies for Full Calendar v3.1 support: https://github.com/fullcalendar/fullcalendar/releases/tag/v3.1.0